### PR TITLE
Find all matches

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -22,15 +22,13 @@ export default class DistrictRepository {
         }, {})
     }
 
-    findAllMatches(string) {
+    findAllMatches(string = '') {
         const keys = Object.keys(this.data);
 
-        if (string) {
-            return keys.filter( (district) => {
-                return district.toUpperCase().includes(string.toUpperCase());
-            })
-        }
-
-        return keys;
+        return keys.filter( (district) => {
+            if (district.toUpperCase().includes(string.toUpperCase())) {
+                return this.data[district]
+            }
+        })
     }
 }

--- a/src/helper.js
+++ b/src/helper.js
@@ -28,5 +28,7 @@ export default class DistrictRepository {
                 return district.toUpperCase().includes(string.toUpperCase());
             })
         }
+
+        return Object.keys(this.data);
     }
 }

--- a/src/helper.js
+++ b/src/helper.js
@@ -21,4 +21,8 @@ export default class DistrictRepository {
             return newData;
         }, {})
     }
+
+    findAllMatches() {
+        
+    }
 }

--- a/src/helper.js
+++ b/src/helper.js
@@ -23,12 +23,14 @@ export default class DistrictRepository {
     }
 
     findAllMatches(string) {
+        const keys = Object.keys(this.data);
+
         if (string) {
-            return Object.keys(this.data).filter( (district) => {
+            return keys.filter( (district) => {
                 return district.toUpperCase().includes(string.toUpperCase());
             })
         }
 
-        return Object.keys(this.data);
+        return keys;
     }
 }

--- a/src/helper.js
+++ b/src/helper.js
@@ -25,10 +25,12 @@ export default class DistrictRepository {
     findAllMatches(string = '') {
         const keys = Object.keys(this.data);
 
-        return keys.filter( (district) => {
+        return keys.reduce( (filteredDistricts, district) => {
             if (district.toUpperCase().includes(string.toUpperCase())) {
-                return this.data[district]
+                filteredDistricts.push(this.data[district])
             }
-        })
+
+            return filteredDistricts
+        }, [])
     }
 }

--- a/src/helper.js
+++ b/src/helper.js
@@ -22,7 +22,11 @@ export default class DistrictRepository {
         }, {})
     }
 
-    findAllMatches() {
-        
+    findAllMatches(string) {
+        if (string) {
+            return Object.keys(this.data).filter( (district) => {
+                return district.toUpperCase().includes(string.toUpperCase());
+            })
+        }
     }
 }


### PR DESCRIPTION
- Build `findAllMatches` function in helper.js
- Set `findAllMatches` to filter through `Object.keys(this.data)` to compare passed string to all district names
- Set implicit return of all `this.data` keys when no arguments passed
- Refactor code to use `keys` variable for all instances of `Object.keys(this.data)`

EDIT
- Refactor to have default value for empty string if no argument passed
- Changed from `filter` to `reduce` to return array with filtered objects versus strings