### PR TITLE
Test setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,14 @@
   "version": "0.1.0",
   "private": true,
   "devDependencies": {
-    "react-scripts": "0.9.0"
+    "enzyme": "^3.2.0",
+    "enzyme-adapter-react-15": "^1.0.5",
+    "react-scripts": "0.9.0",
+    "react-test-renderer": "^15.6.2"
   },
   "dependencies": {
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "react": "^15.6.2",
+    "react-dom": "^15.6.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,14 @@
   "devDependencies": {
     "enzyme": "^3.2.0",
     "enzyme-adapter-react-15": "^1.0.5",
+    "eslint": "^4.12.0",
+    "eslint-plugin-react": "^7.5.1",
     "react-scripts": "0.9.0",
     "react-test-renderer": "^15.2.0"
   },
   "dependencies": {
-    "react": "^15.6.2",
-    "react-dom": "^15.6.2"
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "enzyme": "^3.2.0",
     "enzyme-adapter-react-15": "^1.0.5",
     "react-scripts": "0.9.0",
-    "react-test-renderer": "^15.6.2"
+    "react-test-renderer": "^15.2.0"
   },
   "dependencies": {
     "react": "^15.6.2",

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,12 @@ import React, { Component } from 'react';
 import './App.css';
 
 class App extends Component {
+  constructor() {
+    super();
+    this.state = {
+      data: {}
+    }
+  }
   render() {
     return (
       <div>Welcome To Headcount 2.0</div>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App from '../../src/App';
+import App from './App';
 import { shallow, mount, render } from 'enzyme';
-import importedData from '../../data/kindergartners_in_full_day_program.js'
+// import importedData from '../../data/kindergartners_in_full_day_program.js'
 
 // import { configure } from 'enzyme';
 // import Adapter from 'enzyme-adapter-react-15';

--- a/src/__snapshots__/App.test.js.snap
+++ b/src/__snapshots__/App.test.js.snap
@@ -1,0 +1,1 @@
+exports[`App Tests App should match the snapshot 1`] = `undefined`;

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,6 @@
+const localStorageMock = {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    clear: jest.fn()
+  };
+  global.localStorage = localStorageMock

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,3 +1,8 @@
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-15';
+
+configure({ adapter: new Adapter() });
+
 const localStorageMock = {
     getItem: jest.fn(),
     setItem: jest.fn(),

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -2,10 +2,3 @@ import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-15';
 
 configure({ adapter: new Adapter() });
-
-const localStorageMock = {
-    getItem: jest.fn(),
-    setItem: jest.fn(),
-    clear: jest.fn()
-  };
-  global.localStorage = localStorageMock

--- a/test/unit/App.test.js
+++ b/test/unit/App.test.js
@@ -4,10 +4,10 @@ import App from '../../src/App';
 import { shallow, mount, render } from 'enzyme';
 import importedData from '../../data/kindergartners_in_full_day_program.js'
 
-import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-15';
+// import { configure } from 'enzyme';
+// import Adapter from 'enzyme-adapter-react-15';
 
-configure({ adapter: new Adapter() });
+// configure({ adapter: new Adapter() });
 
 describe('App Tests', () => {
 

--- a/test/unit/App.test.js
+++ b/test/unit/App.test.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from '../../src/App';
+import { shallow, mount, render } from 'enzyme';
+import importedData from '../../data/kindergartners_in_full_day_program.js'
+
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-15';
+
+configure({ adapter: new Adapter() });
+
+describe('App Tests', () => {
+
+    let renderedApp;
+
+    beforeEach( () => {
+        renderedApp = shallow(<App />)
+    })
+
+    it('App should exist', () => {
+        expect(renderedApp).toBeDefined();
+    });
+
+    it('App should match the snapshot', () => {
+        expect(renderedApp).toMatchSnapshot();
+    });
+
+    it('Should have default state', () => {
+        const defaultState = {};
+        expect(renderedApp.state().data).toEqual(defaultState);
+    });
+
+    it('Should take data as state', () => {
+        const defaultState = {}
+        const expectedState = importedData;
+
+        renderedApp.state().data = defaultState;
+        expect(renderedApp.state().data).toEqual(defaultState);
+
+        renderedApp.instance().setState({data: expectedState});
+        expect(renderedApp.state().data).toEqual(expectedState)
+    });
+})

--- a/test/unit/__snapshots__/App.test.js.snap
+++ b/test/unit/__snapshots__/App.test.js.snap
@@ -1,0 +1,45 @@
+exports[`App Tests App should match the snapshot 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <App />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": "Welcome To Headcount 2.0",
+    },
+    "ref": null,
+    "rendered": "Welcome To Headcount 2.0",
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": "Welcome To Headcount 2.0",
+      },
+      "ref": null,
+      "rendered": "Welcome To Headcount 2.0",
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactFifteenAdapter {
+      "options": Object {
+        "supportPrevContextArgumentOfComponentDidUpdate": true,
+      },
+    },
+  },
+}
+`;


### PR DESCRIPTION
- Create `setupTests.js` and built out adapted for `enzyme`
- `npm install` necessary react and enzyme libraries to `package.json`
- Build constructor in `App.js` and `setState` to have data as empty object
- Snapshots folder created through testing suite 
- Preliminary tests for `App.test.js`

Note to Jhun:
`App.test.js` unable to speak to `setupTests.js` and use adapted. Workaround is to put adapter into the test file, however, this would have to be for each test file (redundant code). 

If adapter is _not_ in test file, the following error message occurs:
```
          Enzyme Internal Error: Enzyme expects an adapter to be configured, but found none. To
          configure an adapter, you should call `Enzyme.configure({ adapter: new Adapter() })`
          before using any of Enzyme's top level APIs, where `Adapter` is the adapter
          corresponding to the library currently being tested. For example:

          import Adapter from 'enzyme-adapter-react-15';

          To find out more about this, see http://airbnb.io/enzyme/docs/installation/index.html
```
Additionally tried moving `App.test.js` to `src/` to no avail. Tried `npm install` for different version of all react libraries as well.